### PR TITLE
Add community calls page

### DIFF
--- a/COMMUNITY_CALLS.md
+++ b/COMMUNITY_CALLS.md
@@ -12,7 +12,7 @@ Please refer to this [community meeting doc](https://docs.google.com/document/d/
 | Date | Recording + Transcript |
 |------| -----------------------|
 | 2026-06-16 | [Recording link](https://drive.google.com/file/d/1YatZNqOxJ-_Lhzo7BsE397PiUaabBxIP/view?usp=drive_link)|
-| 2026-06-02 | not available|
+| 2026-06-02 | Intro Call - Not Recorded |
 
 
 ## 🔔 Stay Informed

--- a/COMMUNITY_CALLS.md
+++ b/COMMUNITY_CALLS.md
@@ -1,0 +1,21 @@
+# Platform Mesh Community Calls
+
+Welcome to the Platform Mesh community!
+
+Here you can find all Platform Mesh open source community calls — agendas, recordings, and notes. You're very welcome to join us in the upcoming community calls where we discuss progress, ideas, questions and sometimes live demo 🌈
+
+## 📅 Meeting dates and agenda
+Please refer to this [community meeting doc](https://docs.google.com/document/d/1uYeJPVNBV4_HfgQI65ktAF-O-uASdCXiv-oNqCfy0oU/edit?tab=t.0) for meeting dates, agenda suggestion and meeting notes.
+
+## 🗂️ Past Calls
+
+| Date | Recording + Transcript |
+|------| -----------------------|
+| 2026-06-16 | [Recording link](https://drive.google.com/file/d/1YatZNqOxJ-_Lhzo7BsE397PiUaabBxIP/view?usp=drive_link)|
+| 2026-06-02 | not available|
+
+
+## 🔔 Stay Informed
+
+- Subscribe to the community calendar: [here](https://zoom-lfx.platform.linuxfoundation.org/meetings/platform-mesh?view=week)
+- Join discussions: [zulip](https://linuxfoundation.zulipchat.com/#narrow/channel/532985-neonephos-platform-mesh-discussion/topic/community.20meetings/with/603643643)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ If you are looking for information on how to join us, you are in the right place
 
 ## Community Calls
 
-We meet bi-weekly Tuesday at 16:00 CET/CEST. Checkout [COMMUNITY_CALLS.md](COMMUNITY_CALLS.md) file for more community meetings info such as dates, agenda and watch past recordings.
+We meet bi-weekly Tuesday at 16:00 CET/CEST[(map to your timezone)](https://www.timeanddate.com/worldclock/converter.html?iso=20260616T140000&p1=1440&p2=4826&p3=234&p4=195&p5=83). Checkout [COMMUNITY_CALLS.md](COMMUNITY_CALLS.md) file for more community meetings info such as dates, agenda and watch past recordings.
 
 ## Security / Disclosure
 If you find any bug that may be a security problem, please follow our instructions at [in our security policy](SECURITY.md) on how to report it. Please do not create GitHub issues for security-related doubts or problems.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Welcome to the PlatformMesh community page!
 
 If you are looking for information on how to join us, you are in the right place. Read on to find out how you can get involved, contribute to PlatformMesh code and documentation, and stay in touch with the latest PlatformMesh news. Let's get started!
 
+## Community Calls
+
+We meet bi-weekly Tuesday at 16:00 CET/CEST. Checkout [COMMUNITY_CALLS.md](COMMUNITY_CALLS.md) file for more community meetings info such as dates, agenda and watch past recordings.
+
 ## Security / Disclosure
 If you find any bug that may be a security problem, please follow our instructions at [in our security policy](SECURITY.md) on how to report it. Please do not create GitHub issues for security-related doubts or problems.
 


### PR DESCRIPTION
Create a new page to track our community calls. Here we can find
- Meeting agenda doc
- Recording history
- Subscribe to our public calendar and join zulip channel for community meetings

